### PR TITLE
Return Home function shift to original position

### DIFF
--- a/src/devices/lcd_hd44780.cc
+++ b/src/devices/lcd_hd44780.cc
@@ -462,6 +462,7 @@ void lcd_cmd(lcd_t * lcd, char cmd)
   if(cmd & 0x02 )
   {
     lcd->ddram_ad=0;
+    lcd->shift=0;
     lcd->update=1;  
     return;
   }


### PR DESCRIPTION
Return Home function per Hitachi datasheet: "Sets DDRAM address 0 in address counter. _**Also returns display from being shifted to original position.**_ DDRAM contents remain unchanged."