### PR TITLE
Add instructions for running the prebuilt Windows executable in Wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ tty0tty 	- For serial emulation in linux    https://github.com/lcgamboa/tty0tty
 
 https://github.com/lcgamboa/picsimlab/releases
 
+If you are on macOS you can run picsimlab using Wine:
+
+- Download and install [`xquarts`](https://www.xquartz.org)
+- Download and install [Wine](https://dl.winehq.org/wine-builds/macosx/download.html)
+- Download the executable and double-click it to run the installer
+
 ## Install from source
 
 In Debian Linux and derivatives:


### PR DESCRIPTION
I'm not sure if you knew this or not, but picsimlab runs in Wine! It runs really well, too. I figured this might be useful to some people coming across this project looking for macOS builds - in releases, there is only Linux and Windows so that might discourage people otherwise, hopefully this will provide a way for macOS people to use picsimlab until there are also macOS releases if you're planning on those.