### PR TITLE
Add *.o and other files generated after compiling to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 # Build folder
 build_all/
+
+# Other files generated after compiling
+*.o
+src/picsimlab
+tools/PinViewer/PinViewer
+tools/espmsim/espmsim
+tools/srtank/srtank


### PR DESCRIPTION
After running make, various `.o` and executable files are created in `src` directory, but they are not ignored by git. This PR adds them to `.gitignore` in order to prevent accidental commits with build files.