### PR TITLE
Spare parts not updating till the end

### DIFF
--- a/src/sim_backend/bsim_qemu.cc
+++ b/src/sim_backend/bsim_qemu.cc
@@ -97,9 +97,8 @@ static int64_t GotoNow(void) {
 static void picsimlab_write_pin(int pin, int value) {
     // printf("================> IO    <====================== %ji\n", now - g_board->timer.last);
     ioupdated = 1;
-    g_board->Run_CPU_ns(GotoNow());
-
     g_pins[pin - 1].value = value;
+    g_board->Run_CPU_ns(GotoNow());
     // printf("pin[%i]=%i\n", pin, value);
 }
 


### PR DESCRIPTION
This is a fix to a problem I encountered when using esp32 qemu with spi + led matrix.

This problem happens only if the firmware do not do anything after sending the spi transaction to the max7219.
The last row in my case case missing until a uart data is output or if I input some uart that to generate a pin change.
See the video to illustrate the issue:

https://github.com/user-attachments/assets/1f235911-a21e-4acd-a06e-5bf19c0c38d1

