### PR TITLE
fixed compilation issues when building using non system dir (local build only)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@ override CXXFLAGS+= -D_ARCH_=\"Linux64_WX\" -D_DATE_=\"${DATE}\"
 override CXXFLAGS+= -D_VERSION_=\"$(VERSION)\" -Wall -g -O2 -flto=auto -D_SHARE_=\"../share/picsimlab/\" \
 -D_LIB_=\"../lib/picsimlab/\" `lxrad-config --cxxflags`
 override CXXFLAGS+= -DEXT_BROWSER
+override CXXFLAGS+= -I${prefix}/include -L${prefix}/lib
 #override CXXFLAGS+=-fsanitize=address
 #override CXXFLAGS+=-fno-omit-frame-pointer
 
@@ -52,7 +53,8 @@ install: all
 	strip ${execdir}picsimlab	
 	xdg-icon-resource install --size 64  --novendor ../share/picsimlab.png 
 	xdg-icon-resource install --context mimetypes --size 64 ../share/application-x-picsimlab-workspace.png application-x-picsimlab-workspace
-	xdg-mime install --mode system ../share/application-x-picsimlab-workspace.xml
+	#no need for --mode system, xdg-mime will install to system if executed under root
+	xdg-mime install ../share/application-x-picsimlab-workspace.xml
 	xdg-mime default picsimlab.desktop application/x-picsimlab-workspace
 	update-mime-database /usr/share/mime &
 	update-desktop-database ${appdir} &


### PR DESCRIPTION
I have a modified build script that sets DESTDIR everywhere an install is needed.
This is to avoid using sudo.

```
cl make clean;make -j$(nproc) DESTDIR=${INSTDIR}
cl make install DESTDIR=${INSTDIR}
```

Of course this necessitate to specify LD_LIBRARY_PATH before launching picsimlab as the linker command is missing the rpath argument, but at least this is a portable build