### PR TITLE
macOS initial support

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,37 @@
+name: macOS build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  buildMacOS:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-26
+          - macos-26-intel
+
+    steps:
+      - name: Job info
+        run: |
+          echo "GitHub Ref: ${{ github.ref }}"
+          echo "Event: ${{ github.event }}"
+
+      - name: Checkout sources
+        uses: actions/checkout@v7
+
+      - name: Set DESTDIR
+        run: echo "DESTDIR=${{ github.workspace }}/staging" >> $GITHUB_ENV
+
+      - name: Build and install
+        run: bscripts/build_all_and_install_macos.sh
+
+      - name: Build dmg
+        run: bscripts/make_macos_bundle_and_dmg.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.os }}
+          path: macos/PICSimLab.dmg

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,43 @@
+name: macOS release
+
+on:
+  workflow_run:
+    workflows:
+      - macOS build
+    types: [completed]
+
+jobs:
+  releaseMacOS:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dmg images
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          path: release_assets
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rename dmg images
+        run: |
+          mkdir release_assets_ready
+          mv release_assets/macos-26/PICSimLab.dmg release_assets_ready/PICSimLab-nightly-arm64.dmg
+          mv release_assets/macos-26-intel/PICSimLab.dmg release_assets_ready/PICSimLab-nightly-x86_64.dmg
+
+      - name: Remove the old nightly release
+        uses: ClementTsang/delete-tag-and-release@v0.3.1
+        with:
+          delete_release: true
+          tag_name: latestbuild_macos
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Latest code build release
+        uses: softprops/action-gh-release@v3
+        with:
+          prerelease: true
+          files: release_assets_ready/*
+          tag_name: latestbuild_macos
+          target_commitish: ${{ github.event.workflow_run.head_sha }}

--- a/bscripts/build_all_and_install_macos.sh
+++ b/bscripts/build_all_and_install_macos.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#show errors in color red 
+set -euo pipefail
+cl()("$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
+
+# We do not support installation into system directories on macOS
+if [ -z "${DESTDIR-}" ]; then
+    echo "Error: DESTDIR environment variable is not set." >&2
+    echo "Building and installing the project on macOS without the DESTDIR variable set is not possible." >&2
+    exit 1
+fi
+mkdir -p ${DESTDIR/#\~/$HOME}
+DESTDIR="$(realpath "${DESTDIR/#\~/$HOME}")"
+
+# Check if Command Line Tools are installed
+if ! xcode-select -p &> /dev/null; then
+    echo "Command Line Developer Tools are not installed."
+    echo "Please run 'xcode-select --install' to install them."
+    exit 1
+else
+    echo "Command Line Developer Tools found at: $(xcode-select -p)"
+fi
+
+# Check for Homebrew
+if ! command -v brew &> /dev/null; then
+    echo "--------------------------------------------------------"
+    echo "Homebrew is required but not installed."
+    echo "Please install it from the official website: https://brew.sh"
+    echo 'ATTENTION! Follow the "Next Steps" instructions to update your .zprofile?'
+    echo "--------------------------------------------------------"
+    exit 1
+fi
+# Check if brew is actually accessible in the path
+# (Sometimes 'brew' is installed but the paths are not set up)
+if [[ ":$PATH:" != *":$(brew --prefix)/bin:"* ]]; then
+    echo "--------------------------------------------------------"
+    echo "Homebrew is installed, but it is not in your PATH."
+    echo 'Please ensure you have run the "Next steps" instructions from the Homebrew installer'
+    echo "--------------------------------------------------------"
+    exit 1
+fi
+echo "Homebrew is installed correctly. Proceeding..."
+
+echo -e "\033[1;32m ---------------------- installing deps from homebrew ---------------------\033[0m"
+brew tap osx-cross/homebrew-avr
+brew trust osx-cross/avr
+brew install -y pkg-config wxwidgets openal-soft cmake avr-gcc libelf gpsim uv
+echo -e "\033[1;32m ---------------------- installing python using uv--- ---------------------\033[0m"
+uv python install
+echo -e "\033[1;32m ---------------------- configuring the build environment -----------------\033[0m"
+# Due to some macOS conflicts openal is not discovered automatically by pkg-config
+export PKG_CONFIG_PATH="$(brew --prefix openal-soft)/lib/pkgconfig:${PKG_CONFIG_PATH-}"
+rm -rf build_all
+cl mkdir -p build_all
+cd build_all
+echo -e "\033[1;32m ---------------------- download deps -------------------------------------\033[0m"
+git clone --depth=1 https://github.com/lcgamboa/picsim.git
+git clone --depth=1 https://github.com/lcgamboa/lxrad.git
+git clone --depth=1 https://github.com/lcgamboa/simavr.git
+git clone --depth=1 https://github.com/lcgamboa/uCsim_picsimlab.git
+git clone --depth=1 --no-single-branch https://github.com/valentingorelov/qemu.git
+echo -e "\033[1;32m ---------------------- build and install picsim ------------------------- \033[0m"
+cd picsim
+cl git pull --no-rebase
+cl make clean
+cl make -j$(getconf _NPROCESSORS_ONLN)
+cl make install
+cd ..
+echo -e "\033[1;32m ---------------------- build and install lxrad -------------------------- \033[0m"
+cd lxrad
+git pull --no-rebase
+cl ./make_deps.sh
+cl ./configure --prefix=${DESTDIR}
+cl make clean
+cl make -j$(getconf _NPROCESSORS_ONLN)
+cl make install
+cd ..
+echo -e "\033[1;32m ---------------------- build and install simavr ------------------------- \033[0m"
+cd simavr
+git pull --no-rebase
+cl make clean
+cl make build-simavr -j$(getconf _NPROCESSORS_ONLN)
+cl make install-simavr
+cd ../
+echo -e "\033[1;32m ---------------------- build and install uCsim -------------------------- \033[0m"
+cd uCsim_picsimlab
+git pull --no-rebase
+cl ./config_linux.sh
+cl make clean
+cl make -j$(getconf _NPROCESSORS_ONLN)
+cd picsimlab
+cl make clean
+cl make -j$(getconf _NPROCESSORS_ONLN)
+cl make install
+cd ../../
+echo -e "\033[1;32m ---------------------- build qemu  ---------------------- \033[0m"
+cd qemu
+cl git checkout -f picsimlab-stm32
+git pull --no-rebase
+cl ./build_libqemu-stm32.sh
+cd build
+cl install -d ../../../lib/qemu/
+cl cp libqemu-stm32.dylib ../../../lib/qemu/
+cd ..
+cl git checkout -f picsimlab-esp32
+cl ./build_libqemu-esp32.sh
+cd build
+cl cp libqemu-xtensa.dylib ../../../lib/qemu/
+cl cp libqemu-riscv32.dylib ../../../lib/qemu/
+cd ..
+cl install -d ../../lib/qemu/fw
+cl cp pc-bios/esp32-v3-rom*.bin pc-bios/esp32c3-rom.bin ../../lib/qemu/fw/
+cd ..
+echo -e "\033[1;32m ---------------------- build and install picsimlab ---------------------- \033[0m"
+cd ../
+cl make clean
+cl make -j$(getconf _NPROCESSORS_ONLN)
+cl make install
+echo -e "\033[1;32mPICSimLab has been built and installed successfully\033[0m"
+echo -e "\033[1;32mYou can run it using \033[1;34m$DESTDIR/bin/picsimlab\033[1;32m command \033[0m"

--- a/bscripts/make_macos_bundle_and_dmg.sh
+++ b/bscripts/make_macos_bundle_and_dmg.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env zsh
+#show errors in color red
+set -euo pipefail
+
+# We do not support installation into system directories on macOS
+if [ -z "${DESTDIR-}" ]; then
+    echo "Error: DESTDIR environment variable is not set." >&2
+    echo "You should set the same value as while calling build_all_and_install_macos.sh" >&2
+    exit 1
+fi
+mkdir -p ${DESTDIR/#\~/$HOME}
+DESTDIR="$(realpath "${DESTDIR/#\~/$HOME}")"
+
+# Check for Homebrew
+if ! command -v brew &> /dev/null; then
+    echo "--------------------------------------------------------"
+    echo "Homebrew is required but not installed."
+    echo "Please install it from the official website: https://brew.sh"
+    echo 'ATTENTION! Follow the "Next Steps" instructions to update your .zprofile?'
+    echo "--------------------------------------------------------"
+    exit 1
+fi
+# Check if brew is actually accessible in the path
+# (Sometimes 'brew' is installed but the paths are not set up)
+if [[ ":$PATH:" != *":$(brew --prefix)/bin:"* ]]; then
+    echo "--------------------------------------------------------"
+    echo "Homebrew is installed, but it is not in your PATH."
+    echo 'Please ensure you have run the "Next steps" instructions from the Homebrew installer'
+    echo "--------------------------------------------------------"
+    exit 1
+fi
+echo "Homebrew is installed correctly. Proceeding..."
+HOMEBREW_PREFIX=$(brew --prefix)
+
+# Install imagemagick to convert svg to png
+brew install -y imagemagick create-dmg
+
+# The path to this script
+SCRIPTDIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
+
+# Create an app bundle template
+cd ${SCRIPTDIR}/../macos
+rm -rf PICSimLab.app
+mkdir PICSimLab.app
+mkdir PICSimLab.app/Contents
+mkdir PICSimLab.app/Contents/MacOS
+mkdir PICSimLab.app/Contents/lib
+mkdir PICSimLab.app/Contents/Resources
+
+# Substitute the correct version into Info.plist
+source ../VERSION
+export MACOSX_BUNDLE_SHORT_VERSION_STRING="$VERSION"
+export MACOSX_BUNDLE_BUNDLE_VERSION="$VERSION"
+envsubst < Info.plist.in > PICSimLab.app/Contents/Info.plist
+
+cd PICSimLab.app/Contents/
+
+# Copy executables, libraries and shared files
+cp -P ${DESTDIR}/bin/* MacOS
+cp -P ${DESTDIR}/lib/*.dylib* lib
+cp -rP ${DESTDIR}/lib/picsimlab lib/
+cp -rP ${DESTDIR}/share ./
+
+# Fix library paths and IDs
+typeset -A UNPROCESSED
+for p in MacOS/*; do
+    [[ -e "$p" ]] && UNPROCESSED[$p]=1
+done
+for p in lib/*(.-.); do
+    UNPROCESSED[$p]=1
+done
+for p in lib/picsimlab/qemu/*(.-.); do
+    UNPROCESSED[$p]=1
+done
+while (( ${#UNPROCESSED[@]} > 0 )); do
+    # Pick any key from the associative array
+    exec_path=${${(k)UNPROCESSED}[1]}
+    exec_name=${exec_path##*/}
+    exec_path_original=${UNPROCESSED[$exec_path]}
+
+    echo "Processing: $exec_path"
+    typeset -a LIBS
+    LIBS=( ${(f)"$(otool -L $exec_path | awk 'NR>1 {print $1}')"} )
+    for lib_path in "${LIBS[@]}"; do
+        if [[ "$lib_path" == "${HOMEBREW_PREFIX}"* ]]; then
+            lib_resolved_path=${lib_path:A}
+            lib_name=${lib_resolved_path##*/}
+            lib_install_path="lib/$lib_name"
+            if [[ ! -e "$lib_install_path" ]]; then
+                cp "$lib_resolved_path" "$lib_install_path"
+                UNPROCESSED[$lib_install_path]=${lib_path%/*}
+            fi
+            install_name_tool -change "$lib_path" "@rpath/$lib_name" "$exec_path"
+        elif [[ "$lib_path" == @rpath/* ]]; then
+            # At the moment we assume all the @rpath libs are in the same dir with the lib which references them
+            lib_name=${lib_path##*/}
+            lib_path_file=${exec_path_original}/${lib_name}
+            lib_resolved_path=${lib_path_file:A}
+            lib_name=${lib_resolved_path##*/}
+            lib_install_path="lib/$lib_name"
+            if [[ ! -e $lib_install_path ]]; then
+                cp "$lib_resolved_path" "$lib_install_path"
+                UNPROCESSED[$lib_install_path]=${exec_path_original}
+            fi
+            install_name_tool -change "$lib_path" "@rpath/$lib_name" "$exec_path"
+        fi
+    done
+    if [[ "$exec_path" == *.dylib ]]; then
+        install_name_tool -id "@rpath/$exec_name" "$exec_path"
+        for rpath in ${(f)"$(otool -l "$exec_path" | awk '/cmd LC_RPATH/{getline; getline; print $2}')"}; do
+            install_name_tool -delete_rpath "$rpath" "$exec_path"
+        done
+    fi
+    codesign --force -s - "$exec_path"
+    unset "UNPROCESSED[$exec_path]"
+done
+
+# Create an iconset
+rm -rf MyIcon.iconset
+mkdir MyIcon.iconset
+magick ${DESTDIR}/share/picsimlab/logo.svg logo.png
+sips -z 16 16     logo.png --out MyIcon.iconset/icon_16x16.png
+sips -z 32 32     logo.png --out MyIcon.iconset/icon_16x16@2x.png
+sips -z 32 32     logo.png --out MyIcon.iconset/icon_32x32.png
+sips -z 64 64     logo.png --out MyIcon.iconset/icon_32x32@2x.png
+sips -z 128 128   logo.png --out MyIcon.iconset/icon_128x128.png
+sips -z 256 256   logo.png --out MyIcon.iconset/icon_128x128@2x.png
+sips -z 256 256   logo.png --out MyIcon.iconset/icon_256x256.png
+sips -z 512 512   logo.png --out MyIcon.iconset/icon_256x256@2x.png
+sips -z 512 512   logo.png --out MyIcon.iconset/icon_512x512.png
+mv logo.png MyIcon.iconset/icon_512x512@2x.png
+iconutil -c icns MyIcon.iconset
+rm -R MyIcon.iconset
+mv MyIcon.icns Resources/AppIcon.icns
+
+cd ../..
+codesign --force --sign - "PICSimLab.app"
+
+create-dmg \
+  --volname "PICSimLab Installer" \
+  --window-pos 200 120 \
+  --window-size 600 400 \
+  --icon-size 100 \
+  --icon "PICSimLab.app" 175 120 \
+  --hide-extension "PICSimLab.app" \
+  --app-drop-link 425 120 \
+  --overwrite \
+  "PICSimLab.dmg" \
+  "PICSimLab.app"
+
+codesign --force --sign - "PICSimLab.dmg"

--- a/macos/Info.plist.in
+++ b/macos/Info.plist.in
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>BuildMachineOSBuild</key>
+   <string>25G76</string>
+
+   <key>CFBundleDevelopmentRegion</key>
+   <string>en</string>
+
+   <key>CFBundleExecutable</key>
+   <string>picsimlab</string>
+
+   <key>CFBundleIconFile</key>
+   <string>AppIcon</string>
+
+   <key>CFBundleIdentifier</key>
+   <string>com.lcgamboa.picsimlab</string>
+
+   <key>CFBundleInfoDictionaryVersion</key>
+   <string>6.0</string>
+
+   <key>CFBundleName</key>
+   <string>PICSimLab</string>
+
+   <key>CFBundlePackageType</key>
+   <string>APPL</string>
+
+   <key>CFBundleShortVersionString</key>
+   <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+
+   <key>CFBundleSupportedPlatforms</key>
+   <array>
+       <string>MacOSX</string>
+   </array>
+
+   <key>CFBundleVersion</key>
+   <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+
+   <key>DTCompiler</key>
+   <string>com.apple.compilers.llvm.clang.1_0</string>
+
+   <key>DTPlatformBuild</key>
+   <string>25F70</string>
+
+   <key>DTPlatformName</key>
+   <string>macosx</string>
+
+   <key>DTPlatformVersion</key>
+   <string>26.5</string>
+
+   <key>DTSDKBuild</key>
+   <string>25F70</string>
+
+   <key>DTSDKName</key>
+   <string>macosx26.5</string>
+
+   <key>DTXcode</key>
+   <string>2660</string>
+
+   <key>DTXcodeBuild</key>
+   <string>17F113</string>
+
+   <key>LSApplicationCategoryType</key>
+   <string>public.app-category.developer-tools</string>
+
+   <key>LSMinimumSystemVersion</key>
+   <string>26.5</string>
+</dict>
+</plist>

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,16 @@ execdir= ${prefix}/bin/
 # Suppose lxrad-config may be installed locally in DESTDIR
 export PATH := $(abspath ${execdir}):$(PATH)
 
+ifeq ($(shell uname -s),Darwin)
+    ifeq ($(shell command -v brew 2>/dev/null),)
+        $(error Homebrew is required on macOS, but 'brew' was not found in PATH)
+    endif
+    override CXXFLAGS += -I$(shell brew --prefix)/include
+    LDFLAGS := -Wl,-rpath,@executable_path/../lib
+else
+    LDFLAGS := ""
+endif
+
 #lxrad automatic generated block start, don't edit below!
 
 override CXXFLAGS+= -D_ARCH_=\"Linux64_WX\" -D_DATE_=\"${DATE}\"
@@ -44,7 +54,7 @@ all: picsimlab
 	
 picsimlab: $(OBJS) check-lxrad-config
 	@echo "Linking picsimlab"
-	@$(CXX) $(CXXFLAGS) $(OBJS) -opicsimlab $(LIBS) 
+	@$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJS) -opicsimlab $(LIBS)
 
 %.o: %.cc check-lxrad-config
 	@echo "Compiling $<"

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,9 @@ sharedir= ${prefix}/share/picsimlab/
 libdir= ${prefix}/lib/picsimlab/
 execdir= ${prefix}/bin/
 
+# Suppose lxrad-config may be installed locally in DESTDIR
+export PATH := $(abspath ${execdir}):$(PATH)
+
 #lxrad automatic generated block start, don't edit below!
 
 override CXXFLAGS+= -D_ARCH_=\"Linux64_WX\" -D_DATE_=\"${DATE}\"
@@ -33,13 +36,17 @@ LIBS =  `lxrad-config --libs` -lpicsim -lsimavr -lelf $(ELIBS) -lucsim -ldl -lgp
 
 #lxrad automatic generated block end, don't edit above!
 
+check-lxrad-config:
+	@type lxrad-config >/dev/null 2>&1 || { echo "Cannot find lxrad-config"; exit 1; }
+	@touch $@
+
 all: picsimlab
 	
-picsimlab: $(OBJS)
+picsimlab: $(OBJS) check-lxrad-config
 	@echo "Linking picsimlab"
 	@$(CXX) $(CXXFLAGS) $(OBJS) -opicsimlab $(LIBS) 
 
-%.o: %.cc
+%.o: %.cc check-lxrad-config
 	@echo "Compiling $<"
 	@$(CXX) -c $(CXXFLAGS) $< -o $@ 
 
@@ -87,4 +94,4 @@ run: all
 	./picsimlab
 
 clean:
-	$(RM) picsimlab *.o core */*.o 
+	$(RM) picsimlab *.o core */*.o check-lxrad-config

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,14 +50,23 @@ picsimlab: $(OBJS) check-lxrad-config
 	@echo "Compiling $<"
 	@$(CXX) -c $(CXXFLAGS) $< -o $@ 
 
-install: all
-	install -d $(execdir) $(sharedir) ${libdir} $(appdir) ${sharedir}/../icons/hicolor/64x64/apps/ \
+install_app: all
+	install -d $(execdir) ${libdir}
+	install -m 755 picsimlab $(execdir)
+	strip ${execdir}picsimlab
+	$(CP) -PRvf ../lib/* ${libdir}
+ifneq ($(shell uname),Darwin)
+	install -d  $(sharedir) $(appdir) ${sharedir}/../icons/hicolor/64x64/apps/ \
 	${sharedir}/../icons/hicolor/64x64/mimetypes/ ${sharedir}/../mime/application/
-	$(CP) -dvf  ../share/picsimlab.desktop ${appdir} 
-	$(CP) -drvf ../share/* ${sharedir}
-	$(CP) -drvf ../lib/* ${libdir}
-	$(CP) -dvf picsimlab ${execdir}
-	strip ${execdir}picsimlab	
+	$(CP) -Pvf  ../share/picsimlab.desktop ${appdir}/
+	$(CP) -PRvf ../share/* ${sharedir}
+	$(CP) -PRvf ../share/picsimlab.png ${sharedir}/../icons/hicolor/64x64/apps/
+	$(CP) -PRvf ../share/application-x-picsimlab-workspace.png  ${sharedir}/../icons/hicolor/64x64/mimetypes/
+	$(CP) -PRvf ../share/application-x-picsimlab-workspace.xml ${sharedir}/../mime/application/x-picsimlab-workspace.xml
+endif
+
+install: install_app
+ifneq ($(shell uname),Darwin)
 	xdg-icon-resource install --size 64  --novendor ../share/picsimlab.png 
 	xdg-icon-resource install --context mimetypes --size 64 ../share/application-x-picsimlab-workspace.png application-x-picsimlab-workspace
 	#no need for --mode system, xdg-mime will install to system if executed under root
@@ -65,30 +74,22 @@ install: all
 	xdg-mime default picsimlab.desktop application/x-picsimlab-workspace
 	update-mime-database /usr/share/mime &
 	update-desktop-database ${appdir} &
-
-install_app: all
-	install -d $(execdir) $(sharedir) ${libdir} $(appdir) ${sharedir}/../icons/hicolor/64x64/apps/ \
-	${sharedir}/../icons/hicolor/64x64/mimetypes/ ${sharedir}/../mime/application/
-	$(CP) -dvf  ../share/picsimlab.desktop ${appdir}/
-	$(CP) -drvf ../share/* ${sharedir} 
-	$(CP) -drvf ../lib/* ${libdir}
-	$(CP) -dvf picsimlab ${execdir}
-	$(CP) -drvf ../share/picsimlab.png ${sharedir}/../icons/hicolor/64x64/apps/
-	$(CP) -drvf ../share/application-x-picsimlab-workspace.png  ${sharedir}/../icons/hicolor/64x64/mimetypes/
-	$(CP) -drvf ../share/application-x-picsimlab-workspace.xml ${sharedir}/../mime/application/x-picsimlab-workspace.xml
+endif
 
 install_docs:
-	$(CP) -drvf ../docs ${sharedir} 
+	$(CP) -PRvf ../docs ${sharedir}
 		
 
 uninstall:
-	$(RM) -drvf ${sharedir} 
-	$(RM) -drvf ${libdir} 
 	$(RM) -dvf ${execdir}picsimlab
+	$(RM) -drvf ${libdir}
+ifneq ($(shell uname),Darwin)
+	$(RM) -drvf ${sharedir}
 	$(RM) -dvf ${appdir}picsimlab.desktop
 	xdg-icon-resource uninstall  --size 64 --novendor picsimlab
 	xdg-icon-resource uninstall  --context mimetypes --size 64 application-x-picsimlab-workspace
 	xdg-mime uninstall  --mode system ../share/application-x-picsimlab-workspace.xml
+endif
 
 run: all
 	./picsimlab

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,15 +61,15 @@ picsimlab: $(OBJS) check-lxrad-config
 	@$(CXX) -c $(CXXFLAGS) $< -o $@ 
 
 install_app: all
-	install -d $(execdir) ${libdir}
+	install -d $(execdir) ${libdir} $(sharedir)
 	install -m 755 picsimlab $(execdir)
 	strip ${execdir}picsimlab
 	$(CP) -PRvf ../lib/* ${libdir}
+	$(CP) -PRvf ../share/* ${sharedir}
 ifneq ($(shell uname),Darwin)
-	install -d  $(sharedir) $(appdir) ${sharedir}/../icons/hicolor/64x64/apps/ \
+	install -d $(appdir) ${sharedir}/../icons/hicolor/64x64/apps/ \
 	${sharedir}/../icons/hicolor/64x64/mimetypes/ ${sharedir}/../mime/application/
 	$(CP) -Pvf  ../share/picsimlab.desktop ${appdir}/
-	$(CP) -PRvf ../share/* ${sharedir}
 	$(CP) -PRvf ../share/picsimlab.png ${sharedir}/../icons/hicolor/64x64/apps/
 	$(CP) -PRvf ../share/application-x-picsimlab-workspace.png  ${sharedir}/../icons/hicolor/64x64/mimetypes/
 	$(CP) -PRvf ../share/application-x-picsimlab-workspace.xml ${sharedir}/../mime/application/x-picsimlab-workspace.xml

--- a/src/devices/mplabxd.cc
+++ b/src/devices/mplabxd.cc
@@ -32,6 +32,13 @@
 #ifndef _POSIX_SOURCE
 #define _POSIX_SOURCE
 #endif
+
+#ifdef __APPLE__
+// MacOS workaround
+#define _XOPEN_SOURCE 700
+#define _DARWIN_C_SOURCE 1
+#endif
+
 // system headers dependent
 #ifndef _WIN_
 #include <arpa/inet.h>
@@ -52,6 +59,12 @@ static WSADATA wsaData;
 #endif
 #define MSG_NOSIGNAL 0
 #endif
+
+#ifndef MSG_NOSIGNAL
+// a workaround for BSD-based systems
+#define MSG_NOSIGNAL 0
+#endif
+
 // system headers independent
 #include <errno.h>
 #include <stdarg.h>
@@ -184,6 +197,14 @@ int mplabxd_start(void) {
     if ((sockfd = accept(listenfd, (sockaddr*)&cli, &clilen)) < 0) {
         return 1;
     }
+
+#ifdef SO_NOSIGPIPE
+    // a workaround for BSD-based systems
+    int opt = 1;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt)) < 0) {
+        return 1;
+    }
+#endif
 
     setnblock(sockfd);
     dprint("mplabxd: Debug connected!---------------------------------\n");

--- a/src/lib/rcontrol.cc
+++ b/src/lib/rcontrol.cc
@@ -25,6 +25,12 @@
 
 #define _USE_MATH_DEFINES
 
+#ifdef __APPLE__
+// MacOS workaround
+#define _XOPEN_SOURCE 700
+#define _DARWIN_C_SOURCE 1
+#endif
+
 #define dprint \
     if (1) {   \
     } else     \
@@ -50,6 +56,12 @@
 #endif
 #define MSG_NOSIGNAL 0
 #endif
+
+#ifndef MSG_NOSIGNAL
+// a workaround for BSD-based systems
+#define MSG_NOSIGNAL 0
+#endif
+
 // system headers independent
 #include <errno.h>
 #include <math.h>
@@ -209,6 +221,14 @@ static int rcontrol_start(const int client_id) {
     if ((clients[client_id].sockfd = accept(listenfd, (sockaddr*)&cli, &clilen)) < 0) {
         return 1;
     }
+
+#ifdef SO_NOSIGPIPE
+    // a workaround for BSD-based systems
+    int opt = 1;
+    if (setsockopt(clients[client_id].sockfd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt)) < 0) {
+        return 1;
+    }
+#endif
 
     setnblock(clients[client_id].sockfd);
     dprint("rcontrol: Client connected [%i]!---------------------------------\n", client_id);

--- a/src/sim_backend/bsim_qemu.cc
+++ b/src/sim_backend/bsim_qemu.cc
@@ -263,8 +263,15 @@ void bsim_qemu::MSetSimulationRun(int run) {
 }
 
 int bsim_qemu::load_qemu_lib(const char* path) {
-#ifndef _WIN_  // LINUX
-    std::string fullpath = PICSimLab.GetLibPath() + "qemu/" + path + ".so";
+#ifndef _WIN_  // LINUX or macOS
+    std::string fullpath = PICSimLab.GetLibPath() + "qemu/" + path;
+#ifdef __APPLE__
+    // macOS
+    fullpath += ".dylib";
+#else
+    // Linux
+    fullpath += ".so";
+#endif
 
     void* handle = dlopen((const char*)fullpath.c_str(), RTLD_NOW);
     if (handle == nullptr) {

--- a/tools/PinViewer/Makefile
+++ b/tools/PinViewer/Makefile
@@ -44,17 +44,21 @@ all: $(OBJS) check-lxrad-config
 run: all
 	./PinViewer
 
-install: all
-	$(CP) -dvf  ../../share/PinViewer.desktop ${appdir} 
-	$(CP) -dvf PinViewer ${execdir}
-
 install_app: all
-	$(CP) -dvf PinViewer ${execdir}
+	install -d ${execdir}
+	install -m 755 PinViewer ${execdir}
+
+install: install_app
+ifneq ($(shell uname),Darwin)
+	install -d ${appdir}
+	install -m 644 ../../share/PinViewer.desktop ${appdir}
+endif
 
 uninstall:
 	$(RM) -dvf ${execdir}PinViewer
+ifneq ($(shell uname),Darwin)
 	$(RM) -dvf ${appdir}PinViewer.desktop
-
+endif
 
 clean:
 	rm -f PinViewer *.o core check-lxrad-config

--- a/tools/PinViewer/Makefile
+++ b/tools/PinViewer/Makefile
@@ -13,6 +13,9 @@ appdir= ${prefix}/share/applications/
 execdir= ${prefix}/bin/
 sharedir= ${prefix}/share/picsimlab/
 
+# Suppose lxrad-config may be installed locally in DESTDIR
+export PATH := $(abspath ${execdir}):$(PATH)
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS =  -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\"  -Wall -g -O2 `lxrad-config --cxxflags`
@@ -26,11 +29,15 @@ OBJS = pPinViewer.o PinViewer1.o
 
 exp: all
 
-all: $(OBJS)
+check-lxrad-config:
+	@type lxrad-config >/dev/null 2>&1 || { echo "Cannot find lxrad-config"; exit 1; }
+	@touch $@
+
+all: $(OBJS) check-lxrad-config
 	@echo "Linking PinViewer"
 	@$(CC) $(FLAGS) $(OBJS) -oPinViewer $(LIBS)
 
-%.o: %.cc
+%.o: %.cc check-lxrad-config
 	@echo "Compiling $<"
 	@$(CC) -c $(FLAGS) $< 
 
@@ -50,4 +57,4 @@ uninstall:
 
 
 clean:
-	rm -f PinViewer *.o core
+	rm -f PinViewer *.o core check-lxrad-config

--- a/tools/PinViewer/Makefile
+++ b/tools/PinViewer/Makefile
@@ -16,6 +16,12 @@ sharedir= ${prefix}/share/picsimlab/
 # Suppose lxrad-config may be installed locally in DESTDIR
 export PATH := $(abspath ${execdir}):$(PATH)
 
+ifeq ($(shell uname -s),Darwin)
+    LDFLAGS := -Wl,-rpath,@executable_path/../lib
+else
+    LDFLAGS := ""
+endif
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS =  -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\"  -Wall -g -O2 `lxrad-config --cxxflags`
@@ -35,7 +41,7 @@ check-lxrad-config:
 
 all: $(OBJS) check-lxrad-config
 	@echo "Linking PinViewer"
-	@$(CC) $(FLAGS) $(OBJS) -oPinViewer $(LIBS)
+	@$(CC) $(FLAGS) $(LDFLAGS) $(OBJS) -oPinViewer $(LIBS)
 
 %.o: %.cc check-lxrad-config
 	@echo "Compiling $<"

--- a/tools/espmsim/Makefile
+++ b/tools/espmsim/Makefile
@@ -44,16 +44,21 @@ all: $(OBJS) check-lxrad-config
 run: all
 	./espmsim
 
-install: all
-	$(CP) -dvf  ../../share/espmsim.desktop ${appdir} 
-	$(CP) -dvf espmsim ${execdir}
-
 install_app: all
-	$(CP) -dvf espmsim ${execdir}
+	install -d ${execdir}
+	install -m 755 espmsim ${execdir}
+
+install: install_app
+ifneq ($(shell uname),Darwin)
+	install -d ${appdir}
+	install -m 644 ../../share/espmsim.desktop ${appdir}
+endif
 
 uninstall:
 	$(RM) -dvf ${execdir}espmsim
+ifneq ($(shell uname),Darwin)
 	$(RM) -dvf ${appdir}espmsim.desktop
+endif
 
 clean:
 	rm -f espmsim *.o core check-lxrad-config

--- a/tools/espmsim/Makefile
+++ b/tools/espmsim/Makefile
@@ -13,6 +13,9 @@ appdir= ${prefix}/share/applications/
 execdir= ${prefix}/bin/
 sharedir= ${prefix}/share/picsimlab/
 
+# Suppose lxrad-config may be installed locally in DESTDIR
+export PATH := $(abspath ${execdir}):$(PATH)
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS = -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\" -Wall -g -O2 -DLINUX `lxrad-config --cxxflags`
@@ -25,11 +28,16 @@ OBJS = pespmsim.o espmsim1.o espmsim2.o serial.o tcp.o
 #lxrad automatic generated block end, don't edit above!
 
 exp: all
-all: $(OBJS)
+
+check-lxrad-config:
+	@type lxrad-config >/dev/null 2>&1 || { echo "Cannot find lxrad-config"; exit 1; }
+	@touch $@
+
+all: $(OBJS) check-lxrad-config
 	@echo "Linking espmsim"
 	@$(CC) $(FLAGS) $(OBJS) -oespmsim $(LIBS)
 
-%.o: %.cc
+%.o: %.cc check-lxrad-config
 	@echo "Compiling $<"
 	@$(CC) -c $(FLAGS) $< 
 
@@ -48,4 +56,4 @@ uninstall:
 	$(RM) -dvf ${appdir}espmsim.desktop
 
 clean:
-	rm -f espmsim *.o core
+	rm -f espmsim *.o core check-lxrad-config

--- a/tools/espmsim/Makefile
+++ b/tools/espmsim/Makefile
@@ -16,6 +16,12 @@ sharedir= ${prefix}/share/picsimlab/
 # Suppose lxrad-config may be installed locally in DESTDIR
 export PATH := $(abspath ${execdir}):$(PATH)
 
+ifeq ($(shell uname -s),Darwin)
+    LDFLAGS := -Wl,-rpath,@executable_path/../lib
+else
+    LDFLAGS := ""
+endif
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS = -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\" -Wall -g -O2 -DLINUX `lxrad-config --cxxflags`
@@ -35,7 +41,7 @@ check-lxrad-config:
 
 all: $(OBJS) check-lxrad-config
 	@echo "Linking espmsim"
-	@$(CC) $(FLAGS) $(OBJS) -oespmsim $(LIBS)
+	@$(CC) $(FLAGS) $(LDFLAGS) $(OBJS) -oespmsim $(LIBS)
 
 %.o: %.cc check-lxrad-config
 	@echo "Compiling $<"

--- a/tools/picsimlab_tool/Makefile
+++ b/tools/picsimlab_tool/Makefile
@@ -35,11 +35,11 @@ all: $(OBJS)
 run: all
 	./picsimlab_tool
 
-install: all
-	$(CP) -dvf picsimlab_tool ${execdir}
-
 install_app: all
-	$(CP) -dvf picsimlab_tool ${execdir}
+	install -d ${execdir}
+	install -m 755 picsimlab_tool ${execdir}
+
+install: install_app
 
 uninstall:
 	$(RM) -dvf ${execdir}picsimlab_tool

--- a/tools/srtank/Makefile
+++ b/tools/srtank/Makefile
@@ -13,6 +13,9 @@ appdir= ${prefix}/share/applications/
 execdir= ${prefix}/bin/
 sharedir= ${prefix}/share/picsimlab/
 
+# Suppose lxrad-config may be installed locally in DESTDIR
+export PATH := $(abspath ${execdir}):$(PATH)
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS =  -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\"  -Wall -g -O2 `lxrad-config --cxxflags`
@@ -26,11 +29,15 @@ OBJS = psrtank.o srtank1.o srtank2.o  serial.o
 
 exp: all
 
-all: $(OBJS)
+check-lxrad-config:
+	@type lxrad-config >/dev/null 2>&1 || { echo "Cannot find lxrad-config"; exit 1; }
+	@touch $@
+
+all: $(OBJS) check-lxrad-config
 	@echo "Linking srtank"
 	@$(CC) $(FLAGS) $(OBJS) -osrtank $(LIBS)
 
-%.o: %.cc
+%.o: %.cc check-lxrad-config
 	@echo "Compiling $<"
 	@$(CC) -c $(FLAGS) $< 
 
@@ -50,4 +57,4 @@ uninstall:
 
 
 clean:
-	rm -f srtank *.o core
+	rm -f srtank *.o core check-lxrad-config

--- a/tools/srtank/Makefile
+++ b/tools/srtank/Makefile
@@ -16,6 +16,12 @@ sharedir= ${prefix}/share/picsimlab/
 # Suppose lxrad-config may be installed locally in DESTDIR
 export PATH := $(abspath ${execdir}):$(PATH)
 
+ifeq ($(shell uname -s),Darwin)
+    LDFLAGS := -Wl,-rpath,@executable_path/../lib
+else
+    LDFLAGS := ""
+endif
+
 #lxrad automatic generated block start, don't edit below!
 
 FLAGS =  -D_VERSION_=\"$(VERSION)\" -D_SHARE_=\"${sharedir}\"  -Wall -g -O2 `lxrad-config --cxxflags`
@@ -35,7 +41,7 @@ check-lxrad-config:
 
 all: $(OBJS) check-lxrad-config
 	@echo "Linking srtank"
-	@$(CC) $(FLAGS) $(OBJS) -osrtank $(LIBS)
+	@$(CC) $(FLAGS) $(LDFLAGS) $(OBJS) -osrtank $(LIBS)
 
 %.o: %.cc check-lxrad-config
 	@echo "Compiling $<"

--- a/tools/srtank/Makefile
+++ b/tools/srtank/Makefile
@@ -44,17 +44,21 @@ all: $(OBJS) check-lxrad-config
 run: all
 	./srtank
 
-install: all
-	$(CP) -dvf  ../../share/srtank.desktop ${appdir} 
-	$(CP) -dvf srtank ${execdir}
-
 install_app: all
-	$(CP) -dvf srtank ${execdir}
+	install -d ${execdir}
+	install -m 755 srtank ${execdir}
+
+install: install_app
+ifneq ($(shell uname),Darwin)
+	install -d ${appdir}
+	install -m 644 ../../share/srtank.desktop ${appdir}
+endif
 
 uninstall:
 	$(RM) -dvf ${execdir}srtank
+ifneq ($(shell uname),Darwin)
 	$(RM) -dvf ${appdir}srtank.desktop
-
+endif
 
 clean:
 	rm -f srtank *.o core check-lxrad-config


### PR DESCRIPTION
Hello,

I am currently porting PICSimLab to macOS.
My workstation is a MacBook Air M1 with macOS Tahoe 26.5.2.

The work is still in progress, but I believe the current build script I added to the last commit may be useful for someone. However, it **should not be merged now** because it contains links to my fork repos for dependencies.

### What works:

1. Some Arduino examples

### What does not work:

1. Tools menu
2. QEMU-based boards
3. tty0tty

Everything else has not been tested.

I am going to make pull requests into repositories with dependencies as well.